### PR TITLE
Fix updating apk if --append-version is selected

### DIFF
--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -241,11 +241,10 @@ class GPlaycli:
 		for detail, item in zip(details, pkg_todownload):
 			packagename, filename = item
 
-			if filename is None:
-				if self.append_version:
-					filename = detail['docId']+ "-v." + detail['versionString'] + ".apk"
-				else:
-					filename = detail['docId']+ ".apk"
+			if self.append_version:
+				filename = detail['docId']+ "-v." + detail['versionString'] + ".apk"
+			elif filename is None:
+				filename = detail['docId']+ ".apk"
 
 			logger.info("%s / %s %s", position, len(pkg_todownload), packagename)
 


### PR DESCRIPTION
When using --append-version an updated apk was not downloaded (Message: File XXX already exists, skipping.) Reason was a not newly generated filename in download-function. The old one was used instead. This commit fixes the bug.